### PR TITLE
devuan-2.1-standard_1.0_amd64

### DIFF
--- a/devuan-2.1-standard-64/Makefile
+++ b/devuan-2.1-standard-64/Makefile
@@ -1,0 +1,21 @@
+BASEDIR:=$(shell dab basedir)
+
+all: info/init_ok
+	dab bootstrap
+	dab install devuan-keyring
+	dab exec bash -c "echo 9.0 > /etc/debian_version"
+	dab finalize
+
+info/init_ok: dab.conf
+	dab init
+	touch $@
+
+.PHONY: clean
+clean:
+	dab clean
+	rm -f *~
+
+.PHONY: dist-clean
+dist-clean:
+	dab dist-clean
+	rm -f *~

--- a/devuan-2.1-standard-64/dab.conf
+++ b/devuan-2.1-standard-64/dab.conf
@@ -1,0 +1,13 @@
+Suite: ascii
+CacheDir: ../cache
+Source: http://deb.devuan.org/merged SUITE main contrib
+Source: http://deb.devuan.org/merged SUITE-updates main contrib
+Source: http://deb.devuan.org/merged SUITE-security main contrib
+Architecture: amd64
+Name: devuan-2.1-standard
+Version: 1.0
+Section: system
+Maintainer: Alexey Vazhnov <vazhnov@boot-keys.org>
+Infopage: https://devuan.org
+Description: Devuan 2.1 (standard)
+ A small Devuan 2.1 ASCII system including all standard packages.


### PR DESCRIPTION
Works fine with:
* ostype = gentoo
* IPv6 = auto (SLAAC)
* IPv4 = static

Without "ostype" set manually, I get the same error in web interface and in the CLI:
```
 $ sudo pct config 113
400 Result verification failed
ostype: value 'devuan' does not have a value in the enumeration 'debian, ubuntu, centos, fedora, opensuse, archlinux, alpine, gentoo, unmanaged'
pct config <vmid> [OPTIONS]
```