### PR TITLE
devuan-3.0-standard-64

### DIFF
--- a/devuan-3.0-standard-64/Makefile
+++ b/devuan-3.0-standard-64/Makefile
@@ -1,0 +1,21 @@
+BASEDIR:=$(shell dab basedir)
+
+all: info/init_ok
+	dab bootstrap
+	dab install devuan-keyring
+	dab exec bash -c "echo 10.0 > /etc/debian_version"
+	dab finalize
+
+info/init_ok: dab.conf
+	dab init
+	touch $@
+
+.PHONY: clean
+clean:
+	dab clean
+	rm -f *~
+
+.PHONY: dist-clean
+dist-clean:
+	dab dist-clean
+	rm -f *~

--- a/devuan-3.0-standard-64/dab.conf
+++ b/devuan-3.0-standard-64/dab.conf
@@ -1,0 +1,13 @@
+Suite: buster
+CacheDir: ../cache
+Source: http://deb.devuan.org/merged beowulf main contrib
+Source: http://deb.devuan.org/merged beowulf-updates main contrib
+Source: http://deb.devuan.org/merged beowulf-security main contrib
+Architecture: amd64
+Name: devuan-3.0-standard
+Version: 1.1
+Section: system
+Maintainer: Alexey Vazhnov <vazhnov@boot-keys.org>
+Infopage: https://devuan.org
+Description: Devuan 3.0 (standard)
+ A small Devuan 3.0 Beowulf system including all standard packages.


### PR DESCRIPTION
Works fine.
I set `Suite: buster` because of error:
```console
 $ sudo make
unsupported suite 'beowulf'!
dab init
unsupported suite 'beowulf'!
make: *** [Makefile:10: info/init_ok] Error 25
```